### PR TITLE
Resolve rate gap in table 1 by deduplicating edges.

### DIFF
--- a/rec/datasets.py
+++ b/rec/datasets.py
@@ -42,6 +42,10 @@ def load_dataset(dataset_name: str, max_num_edges, seed=0) -> Graph:
         edge_list = load_network_repo_dataset(f"{rec_data_dir}/soc-digg.mtx")
     elif dataset_name == "gowalla":
         edge_list = load_SNAP_dataset(f"{rec_data_dir}/loc-gowalla_edges.txt")
+        # Has each undirected edge twice (fwd/bwd), deduplicate here:
+        num_edges = len(edge_list)
+        edge_list = list(set(map(tuple, map(sorted, edge_list))))
+        assert 2 * len(edge_list) == num_edges
     elif dataset_name == "skitter":
         edge_list = load_SNAP_dataset(f"{rec_data_dir}/as-skitter.txt")
     elif dataset_name == "dblp":
@@ -56,7 +60,8 @@ def load_dataset(dataset_name: str, max_num_edges, seed=0) -> Graph:
         edge_list = edge_list[:max_num_edges]
 
     print("Sorting edge list")
-    edge_list = sorted(map(sorted, edge_list))
+    edge_list = sorted(map(tuple, map(sorted, edge_list)))
+    assert len(set(edge_list)) == len(edge_list), "Duplicate edges found."
 
     print(f"Relabeling vertices...", flush=True)
     edge_array = relabel_vertices(edge_list)

--- a/rec/definitions.py
+++ b/rec/definitions.py
@@ -17,7 +17,7 @@ class Graph:
 
     @property
     def sorted_edge_list(self):
-        return sorted(map(sorted, self.edge_list))
+        return sorted(map(sorted, self.edge_array))
 
     @property
     def degree_entropy(self):


### PR DESCRIPTION
Fixes an issue with the data loader for the Gowalla data, where previously all edges were present twice. Deduplication makes the compression [rate gap reported in table 1](https://arxiv.org/pdf/2305.09705.pdf#page=8) of the paper disappear:

Before:

```
Dataset: gowalla 
Number of nodes: 196591 
Number of edges: 1900654 
BPE of the vertex-sequence under Pólya's Urn (theoretical): 32.106261488755706 
BPE of the graph under Pólya's Urn (theoretical): 11.690885851793528 
Random Edge Coding message length in BPE: 12.190936382950289
```

After:

```
Dataset: gowalla
Number of nodes: 196591
Number of edges: 950327
BPE of the vertex-sequence under Pólya's Urn (theoretical): 32.30646701686284
BPE of the graph under Pólya's Urn (theoretical): 12.891085721436923
Random Edge Coding message length in BPE: 12.891192189635778
```

The loader now also verifies that no duplicates are present in any other dataset.